### PR TITLE
Make tickets call more performant

### DIFF
--- a/src/javascripts/ticket_sidebar.js
+++ b/src/javascripts/ticket_sidebar.js
@@ -105,7 +105,15 @@ class TicketSidebar {
 	}
 
 	getRecentTickets() {
-		return this.client.request({ url: `/api/v2/users/${this.requester.id}/tickets/requested.json?sort_by=created_at&sort_order=desc` });
+		return this.client.request({
+			url: `/api/v2/users/${this.requester.id}/tickets/requested.json`,
+			cachable: true,
+      			data: {
+          		exclude_archived: true,
+			sort_by: 'created_at',
+			sort_order: 'desc'
+			}
+		});
 	}
 
 	formatTickets(recent_tickets) {

--- a/src/javascripts/ticket_sidebar.js
+++ b/src/javascripts/ticket_sidebar.js
@@ -108,10 +108,10 @@ class TicketSidebar {
 		return this.client.request({
 			url: `/api/v2/users/${this.requester.id}/tickets/requested.json`,
 			cachable: true,
-      			data: {
-          		exclude_archived: true,
-			sort_by: 'created_at',
-			sort_order: 'desc'
+			data: {
+				exclude_archived: true,
+				sort_by: 'created_at',
+				sort_order: 'desc'
 			}
 		});
 	}
@@ -217,7 +217,7 @@ class TicketSidebar {
 		}
 
 		return parts[0] + ' ' + parts[1].substring(0, 1) + '.';
-	} 
+	}
 
 	getUserById(id) {
 		return this.client.request({ url: `/api/v2/users/${id}.json` });


### PR DESCRIPTION
@zenahirsch 

Hi from Zendesk, we'd appreciate if you'd implement `exclude_archived` to reduce API load from your app. This will exclude archived tickets from any searches on the `requested.json` endpoint. 

Thanks!

Chris